### PR TITLE
Better validation

### DIFF
--- a/pytorch-image-classification/{{cookiecutter and 'code'}}/config.py
+++ b/pytorch-image-classification/{{cookiecutter and 'code'}}/config.py
@@ -1,4 +1,4 @@
-hp_dict = dict(
+default_config = dict(
     # this can be any network from the timm library
     arch = 'resnet18',
 
@@ -24,7 +24,9 @@ hp_dict = dict(
 )
 
 class Config():
-    def __init__(self, init):
+    def __init__(self, init=None):
+        if init is None:
+            init = default_config
         object.__setattr__(self, "_params", dict())
         self.update(init)
 

--- a/pytorch-image-classification/{{cookiecutter and 'code'}}/config.py
+++ b/pytorch-image-classification/{{cookiecutter and 'code'}}/config.py
@@ -11,6 +11,7 @@ default_config = dict(
     lr = 0.0001,
     momentum = 0,
     nesterov = False,
+    batch_size = 16,
 
     # scheduler settings
     gamma = 0.96,

--- a/pytorch-image-classification/{{cookiecutter and 'code'}}/train.sh
+++ b/pytorch-image-classification/{{cookiecutter and 'code'}}/train.sh
@@ -2,4 +2,4 @@
 
 export TF_CPP_MIN_LOG_LEVEL=2
 
-python3 ../code/train.py --epochs 10 -b 16 --seed 0
+python3 ../code/train.py --epochs 10 --seed 0

--- a/pytorch-image-classification/{{cookiecutter and 'code'}}/trial.sh
+++ b/pytorch-image-classification/{{cookiecutter and 'code'}}/trial.sh
@@ -2,4 +2,4 @@
 
 export TF_CPP_MIN_LOG_LEVEL=2
 
-python3 ../code/main.py --epochs 3 -b 16 --seed 0
+python3 ../code/train.py --epochs 3 --seed 0


### PR DESCRIPTION
this is mainly to get a more reliable validation loss history. skipping bprop periodically is hacky and was found to break in two cases:
1) if the training data is reshuffled on every epoch, we end up validating on different batches 
2) if there are dependencies between samples (e.g. patches from the same image), could lead to leakage of training data into validation

to fix, an explicit validation set is used that is fixed for the entire training process.